### PR TITLE
feat(dotnet): add net6.0 build targets

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -17,10 +17,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Setup .NET 5
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.*
+        dotnet-version: 6.0.*
     - name: Build with Nuke
       run: ./build.sh compile
       shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,10 +15,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET 5
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.*
+        dotnet-version: 6.0.*
 
     - name: Publish to NuGet with Nuke
       run: ./build.sh push --nuget-api-key ${{ secrets.NUGET_API_KEY }}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -33,10 +33,13 @@
             "GitHubActions",
             "GitLab",
             "Jenkins",
+            "Rider",
             "SpaceAutomation",
             "TeamCity",
             "Terminal",
-            "TravisCI"
+            "TravisCI",
+            "VisualStudio",
+            "VSCode"
           ]
         },
         "NoLogo": {
@@ -50,6 +53,10 @@
         "PackageSource": {
           "type": "string",
           "description": "NuGet artifact target uri - Defaults to https://api.nuget.org/v3/index.json"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
         },
         "Plan": {
           "type": "boolean",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -39,7 +39,7 @@ class Build : NukeBuild
 
     [Solution] readonly Solution Solution;
     [GitRepository] readonly GitRepository GitRepository;
-    [GitVersion(NoFetch = true, Framework = "net5.0")] readonly GitVersion GitVersion;
+    [GitVersion(NoFetch = true, Framework = "net6.0")] readonly GitVersion GitVersion;
 
     AbsolutePath SourceDirectory => RootDirectory / "src";
     AbsolutePath TestsDirectory => RootDirectory / "tests";

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.6.7]" />
+    <PackageReference Include="Nuke.Common" Version="6.0.1" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.8.1]" />
   </ItemGroup>
 
 </Project>

--- a/samples/WebSample/WebSample.csproj
+++ b/samples/WebSample/WebSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>    
+    <TargetFramework>net6.0</TargetFramework>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/WorkerSample/WorkerSample.csproj
+++ b/samples/WorkerSample/WorkerSample.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dotnet-WorkerSample-E1FD34C8-B239-4D87-8143-0BA5129DDB52</UserSecretsId>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Intility.Extensions.Logging.Elasticsearch/Intility.Extensions.Logging.Elasticsearch.csproj
+++ b/src/Intility.Extensions.Logging.Elasticsearch/Intility.Extensions.Logging.Elasticsearch.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <PackageId>Intility.Extensions.Logging.Elasticsearch</PackageId>
-    <PackageTags>intility;logging;extensions;elasticsearch;elastic</PackageTags>
-    <Description>
-      Enable Elasticsearch logging provider.
-    </Description>
-  </PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+		<PackageId>Intility.Extensions.Logging.Elasticsearch</PackageId>
+		<PackageTags>intility;logging;extensions;elasticsearch;elastic</PackageTags>
+		<Description>
+			Enable Elasticsearch logging provider.
+		</Description>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intility.Extensions.Logging\Intility.Extensions.Logging.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intility.Extensions.Logging\Intility.Extensions.Logging.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Intility.Extensions.Logging.Sentry/Intility.Extensions.Logging.Sentry.csproj
+++ b/src/Intility.Extensions.Logging.Sentry/Intility.Extensions.Logging.Sentry.csproj
@@ -1,25 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <PackageId>Intility.Extensions.Logging.Sentry</PackageId>
-    <PackageTags>intility;logging;extensions;sentry</PackageTags>
-    <Description>
-      Enable Sentry instrumentation and logging provider.
-    </Description>
-  </PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+		<PackageId>Intility.Extensions.Logging.Sentry</PackageId>
+		<PackageTags>intility;logging;extensions;sentry</PackageTags>
+		<Description>
+			Enable Sentry instrumentation and logging provider.
+		</Description>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Sentry.AspNetCore" Version="3.13.0" />
-    <PackageReference Include="Sentry.Serilog" Version="3.13.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Sentry.AspNetCore" Version="3.13.0" />
+		<PackageReference Include="Sentry.Serilog" Version="3.13.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intility.Extensions.Logging\Intility.Extensions.Logging.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intility.Extensions.Logging\Intility.Extensions.Logging.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Intility.Extensions.Logging/Intility.Extensions.Logging.csproj
+++ b/src/Intility.Extensions.Logging/Intility.Extensions.Logging.csproj
@@ -1,22 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <PackageId>Intility.Extensions.Logging</PackageId>
-    <PackageTags>intility;logging;extensions</PackageTags>
-    <Description>
-      Common logging infrastructure with extension primitives. 
-      Please do not install this package directly.
-    </Description>
-  </PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+		<PackageId>Intility.Extensions.Logging</PackageId>
+		<PackageTags>intility;logging;extensions</PackageTags>
+		<Description>
+			Common logging infrastructure with extension primitives.
+			Please do not install this package directly.
+		</Description>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.10.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+	</ItemGroup>
 
 </Project>

--- a/src/Intility.Logging.AspNetCore/Intility.Logging.AspNetCore.csproj
+++ b/src/Intility.Logging.AspNetCore/Intility.Logging.AspNetCore.csproj
@@ -1,32 +1,42 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <PackageId>Intility.Logging.AspNetCore</PackageId>
-    <PackageTags>intility;logging;aspnet;aspnetcore</PackageTags>
-    <Description>
-      This package enables common logging infrastructure to any aspnet 
-      or dotnet project using generic host mechanism. Additional logging 
-      capabilities are available through the extension packages Intility.Extensions.Logging.*
-    </Description>
-  </PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+		<PackageId>Intility.Logging.AspNetCore</PackageId>
+		<PackageTags>intility;logging;aspnet;aspnetcore</PackageTags>
+		<Description>
+			This package enables common logging infrastructure to any aspnet
+			or dotnet project using generic host mechanism. Additional logging
+			capabilities are available through the extension packages Intility.Extensions.Logging.*
+		</Description>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-    <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="1.0.9" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
-    <PackageReference Include="Serilog.Enrichers.Memory" Version="1.0.4" />
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+		<PackageReference Include="Serilog.Enrichers.AssemblyName" Version="1.0.9" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+		<PackageReference Include="Serilog.Enrichers.Memory" Version="1.0.4" />
+		<PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intility.Extensions.Logging\Intility.Extensions.Logging.csproj" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Intility.Extensions.Logging\Intility.Extensions.Logging.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
By adding additional TargetFrameworks we can
let the client decide which target is approriate
for the respective project. Target sensitive
dependencies are defined in their own ItemGroup
that is selective applied based on which build
target the end user is working with.