### PR TITLE
Proposed solution to fix sentry instrumentation

### DIFF
--- a/src/Intility.Extensions.Logging.Sentry/LoggerBuilderExtensions.cs
+++ b/src/Intility.Extensions.Logging.Sentry/LoggerBuilderExtensions.cs
@@ -28,14 +28,6 @@ namespace Intility.Extensions.Logging
                 return builder;
             }
 
-            // ConfigureWebHostDefaults can be called multiple times with additive effect
-            builder.HostBuilder.ConfigureWebHostDefaults(webHostBuilder =>
-            {
-                // runtime instrumentation
-                webHostBuilder.UseSentry((SentryAspNetCoreOptions options) =>
-                    configuration.Bind(options));
-            });
-
             // configure serilog logger
             builder.Configuration.WriteTo.Sentry((SentrySerilogOptions options) => configuration.Bind(options));
 


### PR DESCRIPTION
Replace sentry instrumentation with
integrated instrumentation in Serilog.

Fixes issues where net6 apps fails to
instrument the application because of
breaking changes in IWebHostBuilder.

breaking change:
https://docs.microsoft.com/en-us/aspnet/core/migration/50-to-60-samples?view=aspnetcore-6.0#customize-iwebhostbuilder

sentry serilog docs:
https://docs.sentry.io/platforms/dotnet/guides/serilog/