### PR TITLE
Environment

### DIFF
--- a/Intility.Logging.sln
+++ b/Intility.Logging.sln
@@ -22,6 +22,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSample", "samples\WebSam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkerSample", "samples\WorkerSample\WorkerSample.csproj", "{25312E6A-4BA3-4FDF-AA7C-CF2A10CDA2AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinimalApiSample", "samples\MinimalApiSample\MinimalApiSample.csproj", "{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -104,6 +106,18 @@ Global
 		{25312E6A-4BA3-4FDF-AA7C-CF2A10CDA2AA}.Release|x64.Build.0 = Release|Any CPU
 		{25312E6A-4BA3-4FDF-AA7C-CF2A10CDA2AA}.Release|x86.ActiveCfg = Release|Any CPU
 		{25312E6A-4BA3-4FDF-AA7C-CF2A10CDA2AA}.Release|x86.Build.0 = Release|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Debug|x64.Build.0 = Debug|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Debug|x86.Build.0 = Debug|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Release|x64.ActiveCfg = Release|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Release|x64.Build.0 = Release|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Release|x86.ActiveCfg = Release|Any CPU
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -115,6 +129,7 @@ Global
 		{E5D0E124-FC4E-48A1-B96C-ADA424C8D4BA} = {4073E5F4-CD63-4DAA-864D-83A76827807E}
 		{2C7C52E9-835F-4051-9A5E-7D985545A795} = {A5767C5D-9A48-4485-8D5E-686F34B2B766}
 		{25312E6A-4BA3-4FDF-AA7C-CF2A10CDA2AA} = {A5767C5D-9A48-4485-8D5E-686F34B2B766}
+		{B647AC70-7210-462A-A43C-6EB4AFCB7ED4} = {A5767C5D-9A48-4485-8D5E-686F34B2B766}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B2214E5-8A73-47CE-9C97-4910BC331A86}

--- a/samples/MinimalApiSample/MinimalApiSample.csproj
+++ b/samples/MinimalApiSample/MinimalApiSample.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+	<ProjectReference Include="..\..\src\Intility.Extensions.Logging.Elasticsearch\Intility.Extensions.Logging.Elasticsearch.csproj" />
+	<ProjectReference Include="..\..\src\Intility.Extensions.Logging.Sentry\Intility.Extensions.Logging.Sentry.csproj" />
+	<ProjectReference Include="..\..\src\Intility.Logging.AspNetCore\Intility.Logging.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MinimalApiSample/Program.cs
+++ b/samples/MinimalApiSample/Program.cs
@@ -1,0 +1,52 @@
+using Intility.Extensions.Logging;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseIntilityLogging((ctx, logging) =>
+{
+    logging.UseDefaultEnrichers()
+        .UseElasticsearch()
+        .UseSentry();
+});
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+       new WeatherForecast
+       (
+           DateTime.Now.AddDays(index),
+           Random.Shared.Next(-20, 55),
+           summaries[Random.Shared.Next(summaries.Length)]
+       ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast");
+
+app.Run();
+
+internal record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/samples/MinimalApiSample/Properties/launchSettings.json
+++ b/samples/MinimalApiSample/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:42156",
+      "sslPort": 44363
+    }
+  },
+  "profiles": {
+    "MinimalApiSample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7191;http://localhost:5191",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/MinimalApiSample/appsettings.Development.json
+++ b/samples/MinimalApiSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/MinimalApiSample/appsettings.json
+++ b/samples/MinimalApiSample/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Sentry": {
+    "Dsn": "https://examplePublicKey@o0.ingest.sentry.io/0",
+    "MaxRequestBodySize": "Always",
+    "SendDefaultPii": true,
+    "MinimumBreadcrumbLevel": "Debug",
+    "MinimumEventLevel": "Warning",
+    "AttachStackTrace": true,
+    "Debug": true,
+    "DiagnosticsLevel": "Error"
+  }
+}

--- a/samples/WorkerSample/appsettings.json
+++ b/samples/WorkerSample/appsettings.json
@@ -11,5 +11,15 @@
     "Properties": {
       "Application": "Company.WebApplication1"
     }
+  },
+  "Sentry": {
+    "Dsn": "https://examplePublicKey@o0.ingest.sentry.io/0",
+    "MaxRequestBodySize": "Always",
+    "SendDefaultPii": true,
+    "MinimumBreadcrumbLevel": "Debug",
+    "MinimumEventLevel": "Warning",
+    "AttachStackTrace": true,
+    "Debug": true,
+    "DiagnosticsLevel": "Error"
   }
 }

--- a/src/Intility.Extensions.Logging.Sentry/LoggerBuilderExtensions.cs
+++ b/src/Intility.Extensions.Logging.Sentry/LoggerBuilderExtensions.cs
@@ -29,7 +29,15 @@ namespace Intility.Extensions.Logging
             }
 
             // configure serilog logger
-            builder.Configuration.WriteTo.Sentry((SentrySerilogOptions options) => configuration.Bind(options));
+            builder.Configuration.WriteTo.Sentry((SentrySerilogOptions options) =>
+            {
+                configuration.Bind(options);
+
+                if (string.IsNullOrWhiteSpace(options.Environment))
+                {
+                    options.Environment = builder.Host.HostingEnvironment.EnvironmentName;
+                }
+            });
 
             return builder;
         }


### PR DESCRIPTION
Addresses #47

I found we have access to the `HostingEnvironment` through the `builder.Host` property. This way the consumer doesn't need to specify the environment at all, while we can rely on Hosting internals.

Tested through debugging with Minimal Apis, Web and Workers, and the property was always available.

This can be released as a patch, as the AspNetCore integration we removed did this, so this is expected behavior. Consumers can still specify `Sentry:Environment` if they want it to deviate from the hosts environmentName.

If all looks good @emilkje I'll merge, if not I can implement the original suggestion.