### PR TITLE
feat: allow configuring elastic options

### DIFF
--- a/src/Intility.Extensions.Logging.Elasticsearch/LoggerBuilderExtensions.cs
+++ b/src/Intility.Extensions.Logging.Elasticsearch/LoggerBuilderExtensions.cs
@@ -29,8 +29,9 @@ namespace Intility.Extensions.Logging
             var password = elasticConfig["Password"];
             var indexFormat = elasticConfig["IndexFormat"];
             var versionString = elasticConfig["Version"];
+            bool dataStream = bool.TryParse(elasticConfig["DataStream"], out var result) && result;
 
-            if(string.IsNullOrWhiteSpace(indexFormat))
+            if (string.IsNullOrWhiteSpace(indexFormat))
             {
                 throw new Exception("Failed to initialize Elasticsearch sink", 
                     new ArgumentException($"missing elastic config: {configSection}:IndexFormat"));
@@ -52,6 +53,11 @@ namespace Intility.Extensions.Logging
                 AutoRegisterTemplate = true,
                 AutoRegisterTemplateVersion = versionFormat
             };
+
+            if (dataStream)
+            {
+                options.BatchAction = ElasticOpType.Create;
+            }
 
             if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
             {


### PR DESCRIPTION
I've encountered an issue after updating my elastic indexes to use data streams. The problem prevents my application from writing to the index and is described here: [GitHub Issue URL](https://github.com/serilog-contrib/serilog-sinks-elasticsearch/issues/355).

To address this, I've added a batch Action to the appsettings and the UseElasticsearch extension, which resolves the issue.