### PR TITLE
fix: update dependencies from dependabot PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5.0.1
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,10 +13,10 @@ jobs:
       id-token: write  # enable GitHub OIDC token issuance for trusted publishing
       contents: read    
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
+        uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5.0.1
         with:
           dotnet-version: 10.0.*
 
@@ -28,7 +28,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           flavor: |
             latest=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      - uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}

--- a/src/Intility.Logging.AspNetCore/Intility.Logging.AspNetCore.csproj
+++ b/src/Intility.Logging.AspNetCore/Intility.Logging.AspNetCore.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
 

--- a/tests/Intility.Logging.Tests/Intility.Logging.Tests.csproj
+++ b/tests/Intility.Logging.Tests/Intility.Logging.Tests.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Consolidates all open Dependabot PRs (#158, #159, #160, #161, #162) into a single PR.

### GitHub Actions
| Action | Old | New |
|--------|-----|-----|
| actions/checkout | 5.0.1 | 6.0.0 |
| actions/setup-dotnet | 5.0.0 | 5.0.1 |
| docker/metadata-action | 5.9.0 | 5.10.0 |
| actions/create-github-app-token | 2.1.4 | 2.2.0 |

### NuGet Packages
| Package | Old | New | Notes |
|---------|-----|-----|-------|
| Microsoft.NET.Test.Sdk | 17.14.1 | 18.0.1 | Fixes .NET 10 code coverage issue |
| Serilog.AspNetCore | 9.0.0 | 10.0.0 | .NET 10 support |
| xunit.runner.visualstudio | 3.1.4 | 3.1.5 | Patch release |

## Test plan

- [x] Build succeeds locally
- [x] Tests pass (net9.0, net10.0)
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)